### PR TITLE
Checked if the error returned was that the folder did not exist

### DIFF
--- a/install.go
+++ b/install.go
@@ -33,10 +33,11 @@ func main() {
 
 	// check if gothkit folder already exists, if so, delete
 	fi, err := os.Stat("gothkit")
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		log.Fatal(err)
 	}
-	if fi.IsDir() {
+
+	if fi != nil && fi.IsDir() {
 		fmt.Println("-- deleting gothkit folder cause its already present")
 		if err := os.RemoveAll("gothkit"); err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
I was getting an error on Windows because apparently it throws an error on folder non-existence.

The second line change flows from the first, because if you get that specific error, `fi` doesn't exist, so `fi.isDir()` will fail, and since it doesn't exist, we don't need to remove it.

Apologies in advance if this is non-idiomatic Go code, this is one of my first Go projects. I'm happy to make any modifications needed (or close this issue if there's a better way to resolve this problem).