### PR TITLE
Made Makefile work with Windows

### DIFF
--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -4,6 +4,25 @@ ifneq (,$(wildcard ./.env))
     export
 endif
 
+ifeq ($(OS),Windows_NT)
+	MAIN_PATH = /tmp/bin/main.exe
+	SYNC_ASSETS_COMMAND =	go run github.com/makiuchi-d/arelo@v1.13.1 \
+	--target "./public" \
+	--pattern "**/*.js" \
+	--pattern "**/*.css" \
+	--delay "100ms" \
+	-- templ generate --notify-proxy
+else
+	MAIN_PATH = tmp/bin/main
+	SYNC_ASSETS_COMMAND =	go run github.com/cosmtrek/air@v1.51.0 \
+	--build.cmd "templ generate --notify-proxy" \
+	--build.bin "true" \
+	--build.delay "100" \
+	--build.exclude_dir "" \
+	--build.include_dir "public" \
+	--build.include_ext "js,css"
+endif
+
 # run templ generation in watch mode to detect all .templ files and 
 # re-create _templ.txt files on change, then send reload event to browser. 
 # Default url: http://localhost:7331
@@ -13,7 +32,7 @@ templ:
 # run air to detect any go file changes to re-build and re-run the server.
 server:
 	@go run github.com/cosmtrek/air@v1.51.0 \
-	--build.cmd "go build --tags dev -o tmp/bin/main ./cmd/app/" --build.bin "tmp/bin/main" --build.delay "100" \
+	--build.cmd "go build --tags dev -o ${MAIN_PATH} ./cmd/app/" --build.bin "${MAIN_PATH}" --build.delay "100" \
 	--build.exclude_dir "node_modules" \
 	--build.include_ext "go" \
 	--build.stop_on_error "false" \
@@ -29,13 +48,7 @@ watch-esbuild:
 
 # watch for any js or css change in the assets/ folder, then reload the browser via templ proxy.
 sync_assets:
-	go run github.com/cosmtrek/air@v1.51.0 \
-	--build.cmd "templ generate --notify-proxy" \
-	--build.bin "true" \
-	--build.delay "100" \
-	--build.exclude_dir "" \
-	--build.include_dir "public" \
-	--build.include_ext "js,css"
+	${SYNC_ASSETS_COMMAND}
 
 # start the application in development
 dev:


### PR DESCRIPTION
There are two main changes here:

1. Made the main path reference the created .exe files to fix errors relating to those files needing to be .exe
2. Use Arelo instead of Air for sync_assets because Air always requires a binary and unfortunately Windows has no 'true' binary to reference. 

If a future Air update stops requiring a binary, or allows some command line bypass, part 2 could be removed.

I haven't changed the 'build' command, as I am unsure if you actually want to output an .exe, since you are likely deploying on linux anyway. This just fixes the dev experience, and at least for me meant that I didn't need to run anything other than ```make dev``` in a single terminal.