### PR TITLE
Add simple cron scheduling

### DIFF
--- a/scheduler/schedule.go
+++ b/scheduler/schedule.go
@@ -39,20 +39,69 @@ type schedule struct {
 }
 
 func getDurationTillNextProc(s schedule) time.Duration {
-	currentDate := time.Now()
+	currentTime := time.Now()
 
-	nextMin := calcNextTime(s.min, currentDate.Minute(), minMax, 1)
-	nextHour := calcNextTime(s.hour, currentDate.Hour(), hourMax, 0)
-	nextDay := calcNextTime(s.day, currentDate.Day(), dayMax, 0)
-	nextMonth := calcNextTime(s.month, int(currentDate.Month()), monthMax, 0)
+	nextMonth := calcNextTime(s.month, int(currentTime.Month()), monthMax, 0)
 
-	var nextYear int = currentDate.Year()
-	if nextMonth < int(currentDate.Month()) {
-		nextYear += 1
+	if nextMonth > int(currentTime.Month()) {
+		nextDate := time.Date(
+			currentTime.Year(),
+			time.Month(nextMonth),
+			0,
+			0,
+			0,
+			0,
+			0,
+			currentTime.Location(),
+		)
+		return nextDate.Sub(currentTime)
 	}
 
-	nextDate := time.Date(nextYear, time.Month(nextMonth), nextDay, nextHour, nextMin, 0, 0, currentDate.Location())
-	return nextDate.Sub(currentDate)
+	nextDay := calcNextTime(s.day, currentTime.Day(), dayMax, 0)
+
+	if nextDay > currentTime.Day() {
+		nextDate := time.Date(
+			currentTime.Year(),
+			time.Month(nextMonth),
+			nextDay,
+			0,
+			0,
+			0,
+			0,
+			currentTime.Location(),
+		)
+		return nextDate.Sub(currentTime)
+	}
+
+	nextHour := calcNextTime(s.hour, currentTime.Hour(), hourMax, 0)
+
+	if nextHour > currentTime.Hour() {
+		nextDate := time.Date(
+			currentTime.Year(),
+			time.Month(nextMonth),
+			nextDay,
+			nextHour,
+			0,
+			0,
+			0,
+			currentTime.Location(),
+		)
+		return nextDate.Sub(currentTime)
+	}
+
+	nextMinute := calcNextTime(s.min, currentTime.Minute(), minMax, 1)
+
+	nextDate := time.Date(
+		currentTime.Year(),
+		time.Month(nextMonth),
+		nextDay,
+		nextHour,
+		nextMinute,
+		0,
+		0,
+		currentTime.Location(),
+	)
+	return nextDate.Sub(currentTime)
 }
 
 func calcNextTime(t timing, currentTime, maxVal, wildCardIncrement int) int {
@@ -124,5 +173,4 @@ func convCronTiming(timeOption string, minVal, maxVal int) timing {
 		typ: typ,
 		val: max(min(val, maxVal), minVal),
 	}
-
 }

--- a/scheduler/schedule.go
+++ b/scheduler/schedule.go
@@ -1,0 +1,148 @@
+package scheduler
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const cronRegex = `^(\*|[0-5]?\d)(\/\d+)? (\*|[01]?\d|2[0-3])(\/\d+)? (\*|0?[1-9]|[12]\d|3[01])(\/\d+)? (\*|0?[1-9]|1[0-2])(\/\d+)? (\*|[0-6])(\/\d+)?$`
+
+type timingType int
+
+const (
+	concrete timingType = iota
+	step
+	wildcard
+)
+
+const (
+	minMax     = 60
+	hourMax    = 24
+	dayMax     = 31
+	monthMax   = 12
+	weekdayMax = 6
+)
+
+type timing struct {
+	typ timingType
+	val int
+}
+
+type schedule struct {
+	min     timing
+	hour    timing
+	day     timing
+	month   timing
+	weekday timing
+}
+
+func getDurationTillNextProc(s schedule) time.Duration {
+	currentDate := time.Now()
+
+	var nextMin int
+	if s.min.typ == wildcard {
+		nextMin = currentDate.Minute() + 1
+	} else if s.min.typ == step {
+		stepped := min(currentDate.Minute()+s.min.val, minMax)
+		nextMin = stepped - (stepped % s.min.val)
+	} else {
+		nextMin = s.min.val
+	}
+
+	var nextHour int
+	if s.hour.typ == wildcard {
+		nextHour = currentDate.Hour()
+		if s.min.typ == concrete && nextMin < currentDate.Minute() {
+			nextHour += 1
+		}
+	} else if s.hour.typ == step {
+
+	} else {
+		nextHour = s.hour.val
+	}
+
+	var nextDay int
+	if s.day.typ == wildcard {
+		nextDay = currentDate.Day()
+		if nextHour < currentDate.Hour() {
+			nextDay += 1
+		}
+	} else {
+		nextDay = s.day.val
+	}
+
+	var nextMonth int
+	if s.month.typ == wildcard {
+		nextMonth = int(currentDate.Month())
+		if nextDay < currentDate.Day() {
+			nextMonth += 1
+		}
+	} else {
+		nextMonth = s.month.val
+	}
+
+	var nextYear int = currentDate.Year()
+	if nextMonth < int(currentDate.Month()) {
+		nextYear += 1
+	}
+
+	nextDate := time.Date(nextYear, time.Month(nextMonth), nextDay, nextHour, nextMin, 0, 0, currentDate.Location())
+	return nextDate.Sub(currentDate)
+}
+
+func validateSchedule(schedule string) (bool, error) {
+	ok, err := regexp.MatchString(cronRegex, schedule)
+	if err != nil {
+		return false, err
+	}
+
+	return ok, nil
+}
+
+func parseSchedule(s string) schedule {
+	timings := strings.Split(s, " ")
+
+	min := convCronTiming(timings[0], 0, minMax)
+	hour := convCronTiming(timings[1], 0, hourMax)
+	day := convCronTiming(timings[2], 1, dayMax)
+	month := convCronTiming(timings[3], 1, monthMax)
+	weekday := convCronTiming(timings[4], 0, weekdayMax)
+
+	return schedule{
+		min:     min,
+		hour:    hour,
+		day:     day,
+		month:   month,
+		weekday: weekday,
+	}
+}
+
+func convCronTiming(timeOption string, minVal, maxVal int) timing {
+	if timeOption == "*" {
+		return timing{
+			typ: wildcard,
+			val: minVal,
+		}
+	}
+
+	var typ timingType
+	if ok, _ := regexp.MatchString(`^\*\/\d+$`, timeOption); ok {
+		timeOption = timeOption[2:]
+		typ = step
+	} else {
+		typ = concrete
+	}
+
+	val, err := strconv.Atoi(timeOption)
+	if err != nil {
+		panic("String to int conversion should not have failed for cron string")
+	}
+
+	return timing{
+		typ: typ,
+		val: max(min(val, maxVal), minVal),
+	}
+
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -91,8 +91,6 @@ func (s *Scheduler) Start(ctx context.Context) {
 			case <-ctx.Done():
 			default:
 				s.mutex.Lock()
-				defer s.mutex.Unlock()
-
 				for s.numReady == 0 {
 					s.cv.Wait()
 				}
@@ -119,6 +117,7 @@ func (s *Scheduler) Start(ctx context.Context) {
 
 					return true
 				})
+				s.mutex.Unlock()
 			}
 		}
 	}()

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -1,0 +1,216 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const cronRegex = `^([0-5][0-9]|\*) ([0-1][0-9]|2[0-4]|\*) ([0-2][0-9]|3[0-1]|\*) ([0-9]|1[0-2]|\*) ([0-6]|\*)$`
+
+type schedule struct {
+	min     int
+	hour    int
+	day     int
+	month   int
+	weekday int
+}
+
+type job struct {
+	cmd      func()
+	name     string
+	schedule schedule
+}
+
+type Scheduler struct {
+	cv       *sync.Cond
+	jobs     []job
+	logger   *log.Logger
+	mutex    *sync.Mutex
+	numReady int
+	ready    sync.Map
+}
+
+func New(logger *log.Logger) *Scheduler {
+	mutex := &sync.Mutex{}
+	cv := sync.NewCond(mutex)
+
+	return &Scheduler{
+		cv:       cv,
+		jobs:     nil,
+		logger:   logger,
+		mutex:    mutex,
+		numReady: 0,
+		ready:    sync.Map{},
+	}
+}
+
+func (s *Scheduler) Add(schedule string, cmd func()) (bool, error) {
+	return s.addJob(schedule, cmd, fmt.Sprintf("job-%d", time.Now().UTC().Unix()))
+}
+
+func (s *Scheduler) AddWithName(schedule string, cmd func(), name string) (bool, error) {
+	return s.addJob(schedule, cmd, name)
+}
+
+func (s *Scheduler) addJob(schedule string, cmd func(), name string) (bool, error) {
+	ok, err := validateSchedule(schedule)
+	if err != nil {
+		return false, err
+	}
+
+	if !ok {
+		return false, nil
+	}
+
+	job := job{
+		cmd:      cmd,
+		schedule: parseSchedule(schedule),
+		name:     name,
+	}
+
+	s.mutex.Lock()
+	s.ready.Store(s.numReady, true)
+	s.jobs = append(s.jobs, job)
+	s.numReady += 1
+	s.mutex.Unlock()
+
+	return true, nil
+}
+
+func (s *Scheduler) Start(ctx context.Context) {
+	s.logger.Printf("Starting CRON scheduling with [%d] jobs.", len(s.jobs))
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+			default:
+				s.mutex.Lock()
+				defer s.mutex.Unlock()
+
+				for s.numReady == 0 {
+					s.cv.Wait()
+				}
+
+				s.ready.Range(func(key, _ any) bool {
+					go func() {
+						job := s.jobs[key.(int)]
+
+						duration := getDurationTillNextProc(job.schedule)
+						s.logger.Printf("Scheduling job [%s] | Time till next proc [%s]", job.name, duration)
+
+						time.Sleep(duration)
+						job.cmd()
+
+						s.mutex.Lock()
+						defer s.mutex.Unlock()
+						s.ready.Store(key, true)
+						s.numReady += 1
+						s.cv.Signal()
+					}()
+
+					s.ready.Delete(key)
+					s.numReady -= 1
+
+					return true
+				})
+			}
+		}
+	}()
+}
+
+func getDurationTillNextProc(s schedule) time.Duration {
+	currentDate := time.Now()
+
+	var nextMin int
+	if s.min == -1 {
+		nextMin = currentDate.Minute() + 1
+	} else {
+		nextMin = s.min
+	}
+
+	var nextHour int
+	if s.hour == -1 {
+		nextHour = currentDate.Hour()
+		if nextMin < currentDate.Minute() {
+			nextHour += 1
+		}
+	} else {
+		nextHour = s.hour
+	}
+
+	var nextDay int
+	if s.day == -1 {
+		nextDay = currentDate.Day()
+		if nextHour < currentDate.Hour() {
+			nextDay += 1
+		}
+	} else {
+		nextDay = s.day
+	}
+
+	var nextMonth int
+	if s.month == -1 {
+		nextMonth = int(currentDate.Month())
+		if nextDay < currentDate.Day() {
+			nextMonth += 1
+		}
+	} else {
+		nextMonth = s.month
+	}
+
+	var nextYear int = currentDate.Year()
+	if nextMonth < int(currentDate.Month()) {
+		nextYear += 1
+	}
+
+	nextDate := time.Date(nextYear, time.Month(nextMonth), nextDay, nextHour, nextMin, 0, 0, currentDate.Location())
+	return nextDate.Sub(currentDate)
+}
+
+func validateSchedule(schedule string) (bool, error) {
+	// For now just match basic numerics and wildcards
+	ok, err := regexp.MatchString(cronRegex, schedule)
+	if err != nil {
+		return false, err
+	}
+
+	return ok, nil
+}
+
+func parseSchedule(s string) schedule {
+	timings := strings.Split(s, " ")
+
+	min := convCronTiming(timings[0], -1)
+	hour := convCronTiming(timings[1], -1)
+	day := convCronTiming(timings[2], -1)
+	month := convCronTiming(timings[3], -1)
+	weekday := convCronTiming(timings[4], -1)
+
+	return schedule{
+		min:     min,
+		hour:    hour,
+		day:     day,
+		month:   month,
+		weekday: weekday,
+	}
+}
+
+func convCronTiming(timing string, defaultVal int) int {
+	if timing != "*" {
+		val, err := strconv.Atoi(timing)
+
+		// Conversion should not fail because of regex matching string prior
+		if err != nil {
+			panic("Conversion of cron timing should not have failed")
+		}
+		return val
+	}
+
+	return defaultVal
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -4,22 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"regexp"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 )
-
-const cronRegex = `^([0-5][0-9]|\*) ([0-1][0-9]|2[0-4]|\*) ([0-2][0-9]|3[0-1]|\*) ([0-9]|1[0-2]|\*) ([0-6]|\*)$`
-
-type schedule struct {
-	min     int
-	hour    int
-	day     int
-	month   int
-	weekday int
-}
 
 type job struct {
 	cmd      func()
@@ -51,14 +38,54 @@ func New(logger *log.Logger) *Scheduler {
 }
 
 func (s *Scheduler) Add(schedule string, cmd func()) (bool, error) {
-	return s.addJob(schedule, cmd, fmt.Sprintf("job-%d", time.Now().UTC().Unix()))
+	return s.add(schedule, cmd, fmt.Sprintf("job-%d", time.Now().UTC().Unix()))
 }
 
 func (s *Scheduler) AddWithName(schedule string, cmd func(), name string) (bool, error) {
-	return s.addJob(schedule, cmd, name)
+	return s.add(schedule, cmd, name)
 }
 
-func (s *Scheduler) addJob(schedule string, cmd func(), name string) (bool, error) {
+func (s *Scheduler) Start(ctx context.Context) {
+	s.logger.Printf("Starting CRON scheduling with [%d] jobs.", len(s.jobs))
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+			default:
+				s.mutex.Lock()
+				for s.numReady == 0 {
+					s.cv.Wait()
+				}
+
+				s.ready.Range(func(key, _ any) bool {
+					s.ready.Delete(key)
+					s.numReady -= 1
+
+					go func() {
+						job := s.jobs[key.(int)]
+
+						duration := getDurationTillNextProc(job.schedule)
+						s.logger.Printf("Scheduling job [%s] | Time till next proc [%s]", job.name, duration)
+
+						time.Sleep(duration)
+						job.cmd()
+
+						s.mutex.Lock()
+						defer s.mutex.Unlock()
+						s.ready.Store(key, true)
+						s.numReady += 1
+						s.cv.Signal()
+					}()
+
+					return true
+				})
+				s.mutex.Unlock()
+			}
+		}
+	}()
+}
+
+func (s *Scheduler) add(schedule string, cmd func(), name string) (bool, error) {
 	ok, err := validateSchedule(schedule)
 	if err != nil {
 		return false, err
@@ -81,135 +108,4 @@ func (s *Scheduler) addJob(schedule string, cmd func(), name string) (bool, erro
 	s.mutex.Unlock()
 
 	return true, nil
-}
-
-func (s *Scheduler) Start(ctx context.Context) {
-	s.logger.Printf("Starting CRON scheduling with [%d] jobs.", len(s.jobs))
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-			default:
-				s.mutex.Lock()
-				for s.numReady == 0 {
-					s.cv.Wait()
-				}
-
-				s.ready.Range(func(key, _ any) bool {
-					go func() {
-						job := s.jobs[key.(int)]
-
-						duration := getDurationTillNextProc(job.schedule)
-						s.logger.Printf("Scheduling job [%s] | Time till next proc [%s]", job.name, duration)
-
-						time.Sleep(duration)
-						job.cmd()
-
-						s.mutex.Lock()
-						defer s.mutex.Unlock()
-						s.ready.Store(key, true)
-						s.numReady += 1
-						s.cv.Signal()
-					}()
-
-					s.ready.Delete(key)
-					s.numReady -= 1
-
-					return true
-				})
-				s.mutex.Unlock()
-			}
-		}
-	}()
-}
-
-func getDurationTillNextProc(s schedule) time.Duration {
-	currentDate := time.Now()
-
-	var nextMin int
-	if s.min == -1 {
-		nextMin = currentDate.Minute() + 1
-	} else {
-		nextMin = s.min
-	}
-
-	var nextHour int
-	if s.hour == -1 {
-		nextHour = currentDate.Hour()
-		if nextMin < currentDate.Minute() {
-			nextHour += 1
-		}
-	} else {
-		nextHour = s.hour
-	}
-
-	var nextDay int
-	if s.day == -1 {
-		nextDay = currentDate.Day()
-		if nextHour < currentDate.Hour() {
-			nextDay += 1
-		}
-	} else {
-		nextDay = s.day
-	}
-
-	var nextMonth int
-	if s.month == -1 {
-		nextMonth = int(currentDate.Month())
-		if nextDay < currentDate.Day() {
-			nextMonth += 1
-		}
-	} else {
-		nextMonth = s.month
-	}
-
-	var nextYear int = currentDate.Year()
-	if nextMonth < int(currentDate.Month()) {
-		nextYear += 1
-	}
-
-	nextDate := time.Date(nextYear, time.Month(nextMonth), nextDay, nextHour, nextMin, 0, 0, currentDate.Location())
-	return nextDate.Sub(currentDate)
-}
-
-func validateSchedule(schedule string) (bool, error) {
-	// For now just match basic numerics and wildcards
-	ok, err := regexp.MatchString(cronRegex, schedule)
-	if err != nil {
-		return false, err
-	}
-
-	return ok, nil
-}
-
-func parseSchedule(s string) schedule {
-	timings := strings.Split(s, " ")
-
-	min := convCronTiming(timings[0], -1)
-	hour := convCronTiming(timings[1], -1)
-	day := convCronTiming(timings[2], -1)
-	month := convCronTiming(timings[3], -1)
-	weekday := convCronTiming(timings[4], -1)
-
-	return schedule{
-		min:     min,
-		hour:    hour,
-		day:     day,
-		month:   month,
-		weekday: weekday,
-	}
-}
-
-func convCronTiming(timing string, defaultVal int) int {
-	if timing != "*" {
-		val, err := strconv.Atoi(timing)
-
-		// Conversion should not fail because of regex matching string prior
-		if err != nil {
-			panic("Conversion of cron timing should not have failed")
-		}
-		return val
-	}
-
-	return defaultVal
 }


### PR DESCRIPTION
This PR draft sets up basic cron scheduling. Currently only basic cron strings are accepted, i.e. numerics, wildcards, and steps. 

Example usage within a main file can be seen below:

<img width="803" alt="image" src="https://github.com/anthdm/superkit/assets/37748500/d7dfb7fe-223a-4f61-8d50-26297467a2d2">

Currently, there is no support for specifiying specific days, i.e., Mon, Tue, Wed, Etc..

